### PR TITLE
update import in viewer (matplotlib backend)

### DIFF
--- a/larray/viewer.py
+++ b/larray/viewer.py
@@ -90,16 +90,18 @@ from qtpy.QtGui import (QColor, QDoubleValidator, QIntValidator, QKeySequence,
 from qtpy.QtCore import (Qt, QModelIndex, QAbstractTableModel, QPoint, QItemSelection,
                          QItemSelectionModel, QItemSelectionRange, QVariant, Slot)
 
+from qtpy import QT_VERSION
+
 import numpy as np
 
 try:
     import matplotlib
     from matplotlib.figure import Figure
     try:
+        if QT_VERSION[0] == '4':
+            raise Exception
         from matplotlib.backends.backend_qt5agg import FigureCanvas
         from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-
-        canvas = FigureCanvas(Figure())
     except Exception:
         from matplotlib.backends.backend_qt4agg import FigureCanvas
         from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar

--- a/larray/viewer.py
+++ b/larray/viewer.py
@@ -98,6 +98,8 @@ try:
     try:
         from matplotlib.backends.backend_qt5agg import FigureCanvas
         from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+
+        canvas = FigureCanvas(Figure())
     except Exception:
         from matplotlib.backends.backend_qt4agg import FigureCanvas
         from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar


### PR DESCRIPTION
Trying to import FigureCanvas from matplotlib.backends.backend_qt5agg is not enough. 
The import can goes well even if Qt5 is not installed and then FigureCanvas(figure) will crash. 

Another way would be to test the environment variable 'QT_API' set by qtpy when used. 
os.environ['QT_API'] returns pyqt5/pyqt/pyside if PyQt5/PyQt4/Pyside is used. 
The problem is with Pyside since we don't know the Qt version. 

A final option would be to force the Qt version (to 5).