### PR TITLE
raise an error when invalid arguments are passed to read_excel (fixes #91)

### DIFF
--- a/larray/core.py
+++ b/larray/core.py
@@ -9144,6 +9144,9 @@ def read_excel(filepath, sheetname=0, nb_index=None, index_col=None, na=np.nan, 
         index_col = [index_col]
 
     if engine == 'xlwings':
+        if kwargs:
+            raise TypeError("'{}' is an invalid keyword argument for this function when using the xlwings backend"
+                            .format(list(kwargs.keys())[0]))
         from .excel import open_excel
         with open_excel(filepath) as wb:
             return wb[sheetname].load(index_col=index_col)

--- a/larray/tests/test_la.py
+++ b/larray/tests/test_la.py
@@ -2965,6 +2965,10 @@ age |   0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 | ... \
         assert_array_equal(la[x.arr[1], 0, 'F', x.nat[1], :],
                            [3722, 3395, 3347])
 
+        with self.assertRaisesRegexp(TypeError, "'dtype' is an invalid keyword argument for this function when using "
+                                                "the xlwings backend"):
+            read_excel('test.xlsx', engine='xlwings', dtype=float)
+
     def test_read_excel_pandas(self):
         la = read_excel(abspath('test.xlsx'), '1d', engine='xlrd')
         self.assertEqual(la.ndim, 1)


### PR DESCRIPTION
raise an error when invalid arguments are passed to read_excel (fixes #91)