### PR TITLE
fix #301 : added .axes in API documentation

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -13,11 +13,23 @@ Axis
 
    Axis
 
+Exploring
+---------
+
+=========================== ==============================================================
+Axis.name                   Name of the axis. None in the case of an anonymous axis.
+--------------------------- --------------------------------------------------------------
+:attr:`Axis.labels`         Labels of the axis.
+--------------------------- --------------------------------------------------------------
+:attr:`Axis.labels_summary` Short representation of the labels.
+=========================== ==============================================================
+
+Copying
+-------
+
 .. autosummary::
    :toctree: _generated/
 
-   Axis.labels
-   Axis.labels_summary
    Axis.copy
 
 Searching
@@ -226,6 +238,14 @@ Copying
 
 Inspecting
 ----------
+
+=================== ==============================================================
+LArray.data         Data of the array (Numpy ndarray)
+------------------- --------------------------------------------------------------
+LArray.axes         Axes of the array (AxisCollection)
+------------------- --------------------------------------------------------------
+LArray.title        Title of the array (str)
+=================== ==============================================================
 
 .. autosummary::
    :toctree: _generated/

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -437,6 +437,7 @@ Miscellaneous
    eye
    ipfp
    load_example_data
+   local_arrays
 
 Session
 =======
@@ -445,18 +446,66 @@ Session
    :toctree: _generated/
 
    Session
+
+Exploring
+---------
+
+.. autosummary::
+   :toctree: _generated/
+
    Session.names
+   Session.keys
+   Session.values
+   Session.items
+   Session.summary
+
+Copying
+-------
+
+.. autosummary::
+   :toctree: _generated/
+
+   Session.copy
+
+Selecting
+---------
+
+.. autosummary::
+   :toctree: _generated/
+
+   Session.get
+
+Modifying
+---------
+
+.. autosummary::
+   :toctree: _generated/
+
    Session.add
    Session.get
+
+Filtering/Cleaning
+------------------
+
+.. autosummary::
+   :toctree: _generated/
+
+   Session.filter
+   Session.compact
+
+Load/Save
+---------
+
+.. autosummary::
+   :toctree: _generated/
+
    Session.load
    Session.save
    Session.to_csv
    Session.to_excel
    Session.to_hdf
    Session.to_pickle
-   Session.filter
-   Session.compact
-   Session.copy
+
 
 Viewer
 ======

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -12,7 +12,10 @@ Axis
    :toctree: _generated/
 
    Axis
-   Axis.name
+
+.. autosummary::
+   :toctree: _generated/
+
    Axis.labels
    Axis.labels_summary
    Axis.copy
@@ -64,6 +67,10 @@ PGroup
    :toctree: _generated/
 
    PGroup
+
+.. autosummary::
+   :toctree: _generated/
+
    PGroup.named
    PGroup.with_axis
    PGroup.by
@@ -79,6 +86,10 @@ LGroup
    :toctree: _generated/
 
    LGroup
+
+.. autosummary::
+   :toctree: _generated/
+
    LGroup.named
    LGroup.with_axis
    LGroup.by
@@ -102,6 +113,10 @@ AxisCollection
    :toctree: _generated/
 
    AxisCollection
+
+.. autosummary::
+   :toctree: _generated/
+
    AxisCollection.names
    AxisCollection.display_names
    AxisCollection.labels

--- a/larray/core/axis.py
+++ b/larray/core/axis.py
@@ -177,7 +177,7 @@ class Axis(ABCAxis):
     @property
     def labels(self):
         """
-        List of labels.
+        labels of the axis.
         """
         return self._labels
 


### PR DESCRIPTION
I tried .. autoinstanceattribute ( https://github.com/sphinx-doc/sphinx/issues/904 ) but the result was not as expected and it does not work with autosummary.  