### PR TITLE
updated doc/conf.py and doc/environment.yml

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -8,9 +8,7 @@ dependencies:
   - pandas
   - matplotlib
   - pytables
-  - jupyter
-  - jupyter_client
   - sphinx
   - numpydoc
-  - nbsphinx
   - pandoc
+  - ipython

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'numpydoc',
-    'nbsphinx',
     'sphinx.ext.mathjax',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting'


### PR DESCRIPTION
jupyter scripts are no longer used for the tutorial part of the documentation