### PR TITLE
fix(#580): Renamed sheetname to sheet in to_excel

### DIFF
--- a/doc/source/changes/version_0_28.rst.inc
+++ b/doc/source/changes/version_0_28.rst.inc
@@ -318,6 +318,7 @@ Miscellaneous improvements
 
 * renamed argument `sheetname` of `read_excel` function as `sheet` (closes :issue:`587`).
 
+* Renamed sheet_name of LArray.to_excel to sheet since it can also be an index (closes :issue:580).
 
 Fixes
 -----


### PR DESCRIPTION
Reopen of : https://github.com/liam2/larray/pull/586 / #583 due to tauns of conflicts. I came for a new fresh fork.

I renamed every "sheet" to "sheetobj" in to_excel def.
I renamed every "sheet_name" to "sheet" in to_excel def.
I added a changelog entry in doc/source/changes/version_0_28.rst.inc section "Miscellaneous improvements"

@gdementen @alixdamman There we goooooooooooooooooooo