### PR TITLE
bump version to 0.30-dev

### DIFF
--- a/condarecipe/larray/meta.yaml
+++ b/condarecipe/larray/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: larray
-  version: 0.29
+  version: 0.30-dev
 
 source:
-  git_tag: 0.29
+  git_tag: 0.30-dev
   git_url: https://github.com/larray-project/larray.git
 #  git_tag: master
 #  git_url: file://c:/Users/gdm/devel/larray/.git

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1,6 +1,14 @@
 ﻿Change log
 ##########
 
+Version 0.30
+============
+
+In development.
+
+.. include:: ./changes/version_0_30.rst.inc
+
+
 Version 0.29
 ============
 

--- a/doc/source/changes/version_0_30.rst.inc
+++ b/doc/source/changes/version_0_30.rst.inc
@@ -1,0 +1,32 @@
+﻿Syntax changes
+--------------
+
+* new syntax
+
+
+Backward incompatible changes
+-----------------------------
+
+* backward incompatible changes
+
+
+New features
+------------
+
+* added a feature (see the :ref:`miscellaneous section <misc>` for details).
+
+* added another feature.
+
+
+.. _misc:
+
+Miscellaneous improvements
+--------------------------
+
+* improved something.
+
+
+Fixes
+-----
+
+* fixed something (closes :issue:`1`).

--- a/larray/__init__.py
+++ b/larray/__init__.py
@@ -8,4 +8,4 @@ from larray.extra import *
 from larray.viewer import *
 import larray.random
 
-__version__ = '0.29'
+__version__ = '0.30-dev'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readlocal(fname):
 
 
 DISTNAME = 'larray'
-VERSION = '0.29'
+VERSION = '0.30-dev'
 AUTHOR = 'Gaetan de Menten, Geert Bryon, Johan Duyck, Alix Damman'
 AUTHOR_EMAIL = 'gdementen@gmail.com'
 DESCRIPTION = "N-D labeled arrays in Python"


### PR DESCRIPTION
PR with just the version bump so that we can accept it quickly and I can have clean release notes in my other PRs